### PR TITLE
Add allowList exceptions to instances disabling hub creation #19

### DIFF
--- a/src/lib/plugins/instance-admin/InstanceAdmin.svelte
+++ b/src/lib/plugins/instance-admin/InstanceAdmin.svelte
@@ -53,6 +53,18 @@
 				parse={parseJson}
 				serialize={serializeJson}
 			/>
+			<Alert>
+				when hub creation is disabled, only admins are allowed to create hubs. Names added to this
+				list will be granted an exception.
+			</Alert>
+			<PropertyEditor
+				value={instanceSettings?.allowedHubCreationAccounts}
+				field="allowedHubCreationAccounts"
+				update={updateHubSetting}
+				deletable={true}
+				parse={parseJson}
+				serialize={serializeJson}
+			/>
 			<PropertyEditor
 				value={instanceSettings?.minPasswordLength}
 				field="minPasswordLength"

--- a/src/lib/vocab/hub/hub.ts
+++ b/src/lib/vocab/hub/hub.ts
@@ -1,5 +1,6 @@
 import type {Flavored} from '@ryanatkn/belt/types.js';
 import type {RoleId} from '$lib/vocab/role/role';
+import type {ActorId} from '../actor/actor';
 
 export type HubId = Flavored<number, 'HubId'>;
 
@@ -34,6 +35,7 @@ export interface HubSettings {
 export interface InstanceSettings {
 	allowedAccountNames?: string[];
 	disableCreateHub?: boolean;
+	allowedHubCreationAccounts?: ActorId[];
 	defaultHubIds?: HubId[];
 	minPasswordLength?: number;
 	site?: {

--- a/src/lib/vocab/hub/hubSchema.ts
+++ b/src/lib/vocab/hub/hubSchema.ts
@@ -51,6 +51,7 @@ export const InstanceSettingsSchema = {
 	properties: {
 		allowedAccountNames: {type: 'array', items: {type: 'string'}},
 		disableCreateHub: {type: 'boolean'},
+		allowedHubCreationAccounts: {type: 'array', items: {$ref: '/schemas/ActorId'}},
 		defaultHubIds: {type: 'array', items: {$ref: '/schemas/HubId'}},
 		minPasswordLength: {type: 'number'},
 		site: {

--- a/src/lib/vocab/hub/hubServices.ts
+++ b/src/lib/vocab/hub/hubServices.ts
@@ -97,7 +97,7 @@ export const CreateHubService: ServiceByName['CreateHub'] = {
 		}
 
 		// Check for instance settings OR admin actor
-		if ((await isCreateHubDisabled(repos)) && !(await isActorAdmin(repos, actor))) {
+		if ((await isCreateHubDisabled(repos, actor)) && !(await isActorAdmin(repos, actor))) {
 			return {ok: false, status: 403, message: 'actor does not have permission'};
 		}
 

--- a/src/lib/vocab/policy/policyHelpers.server.ts
+++ b/src/lib/vocab/policy/policyHelpers.server.ts
@@ -43,10 +43,11 @@ export const checkHubAccessForActor = async (
 	}
 };
 
-export const isCreateHubDisabled = async (repos: Repos): Promise<boolean> => {
+export const isCreateHubDisabled = async (repos: Repos, actor: ActorId): Promise<boolean> => {
 	const hub = await repos.hub.loadAdminHub(HUB_COLUMNS.settings);
-	if (hub) {
-		return !!hub.settings.instance?.disableCreateHub;
+	if (hub?.settings.instance) {
+		const {disableCreateHub, allowedHubCreationAccounts} = hub.settings.instance;
+		return !!(disableCreateHub && !allowedHubCreationAccounts?.includes(actor));
 	} else {
 		//if we can't load the adminHub, we won't allow for new hubs to be created
 		return true;


### PR DESCRIPTION
For #19 

Adds allowlist to instance settings to allow non-admins the ability to create hubs