### PR TITLE
LOOM26 - Clarify UX

### DIFF
--- a/src/lib/plugins/lists/ListItem.svelte
+++ b/src/lib/plugins/lists/ListItem.svelte
@@ -182,9 +182,4 @@ And then ActorContextmenu would be only for *session* actors? `SessionActorConte
 		font-size: var(--size_1);
 		padding: 0 var(--spacing_md);
 	}
-	.floating-controls {
-		position: absolute;
-		left: 0;
-		top: 100%;
-	}
 </style>


### PR DESCRIPTION
Removed a confusing expand list button near the expand/collapse button for new list input.